### PR TITLE
Adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Property      | Type        | Default   | Description
 `required`    | *Boolean*   | `false`   | Required validate
 `disabled`    | *Boolean*   | `false`   | Disabled state
 `autofocus`   | *Boolean*   | `false`   | Default autofocus
+`step`        | *Number*    | `0`       | Custom step for number inputs
 
 ## Styling
 

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^6.0.0",
     "iron-test-helpers": "^2.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -259,6 +259,19 @@
         </template>
       </demo-snippet>
 
+      <!-- Custom step - demo
+      ========================= -->
+
+      <h2>Custom step</h2>
+
+      <demo-snippet class="centered-demo">
+        <template>
+
+          <valle-input type="time" step="1"></valle-input>
+
+        </template>
+      </demo-snippet>
+
       <!-- Full input - demo
       ========================= -->
 

--- a/valle-input.html
+++ b/valle-input.html
@@ -102,6 +102,7 @@
       aria-describedby="description"
       autofocus=[[autofocus]]
       value=[[value]]
+      step=[[step]]
     >
 
     <label id="inputLabel" class="label">[[label]]</label>
@@ -329,6 +330,10 @@
           dolar: {
             type: Boolean,
             value: false
+          },
+          step: {
+            type: Number,
+            value: 0
           }
         };
       }

--- a/valle-input.html
+++ b/valle-input.html
@@ -66,8 +66,9 @@
 
       :host([disabled]) .input {
         background-color: initial;
-        border-bottom: 1px dotted rgba(0, 0, 0, .42);
+        border-bottom: 2px solid rgba(0, 0, 0, .38);
         color: rgba(0, 0, 0, .38);
+        cursor: no-drop;
       }
 
       :host([uppercase]) .input {


### PR DESCRIPTION
Old disabled style:

![Screen Shot 2020-02-10 at 14 24 16](https://user-images.githubusercontent.com/6748866/74211722-f42ea580-4c6f-11ea-9132-8212541437ac.png)

New:

![Screen Shot 2020-02-10 at 14 26 15](https://user-images.githubusercontent.com/6748866/74211738-fd1f7700-4c6f-11ea-9d3c-aebdff41a616.png)

Before step prop:

![Screen Shot 2020-02-10 at 17 24 19](https://user-images.githubusercontent.com/6748866/74211709-e24d0280-4c6f-11ea-8dda-5122d623204d.png)

After custom step prop:

![Screen Shot 2020-02-10 at 17 24 35](https://user-images.githubusercontent.com/6748866/74211714-e7aa4d00-4c6f-11ea-8236-5bc64f8fa52c.png)
